### PR TITLE
Add ability to look up SMILES from ChEBI, PubChem, and ChEMBL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+*.pyc
+*.sqlite3
+*.rdb

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ For a SMILES string:
 ```bash
 curl -vvv -d 'smiles=S(=O)(=O)(NC(=O)Nc1nc(OC)cc(OC)n1)Cc2c(cccc2)C(=O)OC' localhost:8000/api/names
 ```
+For a ChEBI identifier:
+```bash
+curl -vvv -d 'smiles=chebi:138488' localhost:8000/api/names
+```
 For a file:
 ```bash
 curl -vvv -X POST -F molecule_file=@'/path/to/your/file/ligands.sdf' localhost:8000/api/names

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+requests
 django==4.1.5
 djangorestframework==3.14.0
 drf-spectacular==0.26.2

--- a/smart_chemist_backend/add_patterns_to_db.py
+++ b/smart_chemist_backend/add_patterns_to_db.py
@@ -1,7 +1,10 @@
 import django
 import pandas as pd
 import os
+from pathlib import Path
 
+HERE = Path(__file__).parent.resolve()
+SMARTS_HIERARCHY_PATH = HERE.parent.joinpath("smarts", "smarts_with_hierarchy.csv").resolve()
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'smart_chemist_backend.settings')
 django.setup()
@@ -9,7 +12,7 @@ from smart_chemist.models import AnnotatedPattern
 
 AnnotatedPattern.objects.all().delete()
 
-data = pd.read_csv("../../smarts/smarts_with_hierarchy.csv", skiprows=1)
+data = pd.read_csv(SMARTS_HIERARCHY_PATH, skiprows=1)
 for index, row in data.iterrows():
     test = AnnotatedPattern.objects.create(smarts=row['SMARTS'],
                                            trivial_name=row['trivialname'],


### PR DESCRIPTION
Rather than putting in SMILES into the fields, you can now use CURIEs like the following to get SMILES (all of these examples are for alsterpaullone:

1. [`chembl.compound:CHEMBL50894`](https://www.ebi.ac.uk/chembl/compound_report_card/CHEMBL50894)
2. [`chebi:138488`](https://bioregistry.io/chebi:138488)
3. [`pubchem.compound:5005498`](https://pubchem.ncbi.nlm.nih.gov/compound/5005498)
